### PR TITLE
updateModelBound() calls updateBound()

### DIFF
--- a/src/docs/asciidoc/jme3/advanced/custom_meshes.adoc
+++ b/src/docs/asciidoc/jme3/advanced/custom_meshes.adoc
@@ -208,8 +208,8 @@ quad.scaleTextureCoordinates(new Vector2f(width , height));
 
 If you are modifying a mesh dynamically in a way which changes the model's bounds, you need to update it:
 
-.  Call `updateBound()` on the mesh object, and then 
-.  call `updateModelBound()` on the Geometry object containing the mesh. 
+.  Call `updateBound()` on the mesh object, or
+.  Call `updateModelBound()` on the Geometry object containing the mesh - which in turns calls `updateBound()` on the mesh. 
 
 The updateModelBound() method warns you about not usually needing to use it, but that can be ignored in this special case.
 


### PR DESCRIPTION
updateModelBound() calls updateBound() internally. So we need to call only one instead of both.
