### PR TITLE
Fix typo in 3.1 pom

### DIFF
--- a/src/docs/asciidoc/jme3/maven.adoc
+++ b/src/docs/asciidoc/jme3/maven.adoc
@@ -98,7 +98,7 @@ dependencies {
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>${jm3_g}</groupId>
+      <groupId>${jme3_g}</groupId>
       <artifactId>jme3-lwjgl</artifactId>
       <version>${jme3_v}</version>
     </dependency>


### PR DESCRIPTION
Noticed the typo when tried to use it in my maven pom.