### PR TITLE
Update file_types.adoc

### DIFF
--- a/src/docs/asciidoc/jme3/intermediate/file_types.adoc
+++ b/src/docs/asciidoc/jme3/intermediate/file_types.adoc
@@ -16,19 +16,19 @@ a|Suffix
 a|Usage
 a|Learn more
 
-a|.j3o
+l|.j3o
 a|Binary 3D model or scene. At the latest from the Beta release of your game on, you should convert all models to .j3o format. +During alpha and earlier development phases (when models still change a lot) you can alternatively load OgreXML/OBJ models directly.
 a|<<sdk/model_loader_and_viewer#,Model Loader and Viewer>> 
 
-a|.j3m
+l|.j3m
 a|A custom Material. You can create a .j3m file to store a Material configuration for a Geometry (e.g. 3D model).
 a|<<jme3/advanced/materials_overview#,Materials Overview>> +<<sdk/material_editing#,Material Editing>> 
 
-a|.j3md
+l|.j3md
 a|A Material definition. These are pre-defined templates for shader-based Materials. +Each custom .j3m Material is based on a material definition. Advanced users can create their own material definitions. 
 a| <<jme3/advanced/materials_overview#,Materials Overview>> 
 
-a|.j3f
+l|.j3f
 a|A custom post-processor filter configuration. You can create a .j3f file to store a FilterPostProcessor with a set of preconfigured filters. 
 a| <<sdk/filters#,Filters>> +<<jme3/advanced/effects_overview#,Effects Overview>> 
 
@@ -43,19 +43,19 @@ a|File Suffix
 a|Type
 a|Description
 
-a|.mesh.xml, .meshxml
+l|.mesh.xml, .meshxml
 a|3D model
 a|Ogre Mesh XML 
 
-a|.scene
+l|.scene
 a|3D scene
 a|Ogre DotScene 
 
-a|.OBJ, .MTL
+l|.OBJ, .MTL
 a|3D model
 a|Wavefront
 
-a|.blend
+l|.blend
 a|3D model
 a|Blender version 2.49 onwards (tested up to 2.65)
 
@@ -75,31 +75,31 @@ a|.JPG, .PNG, .GIF
 a|image
 a|Textures, icons
 
-a|.DDS
+l|.DDS
 a|image
 a|Direct Draw Surface texture
 
-a|.HDR
+l|.HDR
 a|image
 a|High Dynamic Range texture
 
-a|.TGA
+l|.TGA
 a|image
 a|Targa Image File texture
 
-a|.PFM
+l|.PFM
 a|image
 a|Portable Float Map texture
 
-a|.fnt
+l|.fnt
 a|bitmap font
 a|AngelCode font for +++<abbr title="Graphical User Interface">GUI</abbr>+++ and HUD
 
-a|.WAV
+l|.WAV
 a|audio
 a|Wave music and sounds
 
-a|.OGG
+l|.OGG
 a|audio
 a|OGG Vorbis music and sounds
 


### PR DESCRIPTION
Set the columns after the table header to literal (l) because only headers and lists treat text after the dot(.) prefix as literal text. Normal table cells skip text after dot (.) so the text following it is not displayed.