### PR TITLE
Update faq.adoc

### DIFF
--- a/src/docs/asciidoc/jme3/faq.adoc
+++ b/src/docs/asciidoc/jme3/faq.adoc
@@ -15,7 +15,8 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 === How do I start writing a preconfigured jME game?
 
 Write a Java class that extends link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java[com.jme3.app.SimpleApplication].
-+*Learn more:* <<jme3/beginner/hello_simpleapplication#,Hello SimpleApplication>>, link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/app/TestAppStateLifeCycle.java[TestAppStateLifeCycle].
+
+*Learn more:* <<jme3/beginner/hello_simpleapplication#,Hello SimpleApplication>>, link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/app/TestAppStateLifeCycle.java[TestAppStateLifeCycle].
 
 
 === How do I change the background color?
@@ -29,19 +30,22 @@ viewPort.setBackgroundColor(ColorRGBA.Blue);
 === Can I customize the SimpleApplication class?
 
 Yes! Actually, you MUST customize it! For your own games, you always create a custom base class that extends link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/app/SimpleApplication.java[com.jme3.app.SimpleApplication] class. From now on it's no longer a “simple application – it's now your game. Configure your <<jme3/intermediate/appsettings#,application settings>>, implement methods, and customize away!
-+*Learn more:* <<jme3/intermediate/simpleapplication#,SimpleApplication>>, <<jme3/intermediate/appsettings#,AppSettings>>.
+
+*Learn more:* <<jme3/intermediate/simpleapplication#,SimpleApplication>>, <<jme3/intermediate/appsettings#,AppSettings>>.
 
 
 === How can I switch between screens or states?
 
 You should break down your application logic into components by spreading it out over individual AppStates. AppStates can be attached to and detached from the game. AppStates have access to all objects (rootNode, PhysicsSpace, inputManager, etc) and methods in your main application. So each AppState can bring its own subset of input handlers, +++<abbr title="Graphical User Interface">GUI</abbr>+++ nodes, spatial nodes, and even its own subset of game mechanics in the update() loop.
-+*Learn more:* <<jme3/advanced/application_states#,Application States>>.
+
+*Learn more:* <<jme3/advanced/application_states#,Application States>>.
 
 
 === How do I pause/unpause a game?
 
 You split up your application into several AppStates and implement the setEnabled() methods for each state. Then you create, for example, a GameRunningAppState and a GamePausedAppState. GamePausedAppState's job is to attach all your AppStates that contain the logic and +++<abbr title="Graphical User Interface">GUI</abbr>+++ of the pause screen, and to detach all the AppStates that contain logic and +++<abbr title="Graphical User Interface">GUI</abbr>+++ of the running game. GameRunningAppState does the opposite. By attaching one or the other to the game, you switch between the paused and unpaused states.
-+*Learn more:* <<jme3/advanced/application_states#,Application States>>.
+
+*Learn more:* <<jme3/advanced/application_states#,Application States>>.
 
 
 === How do I disable logger output to the console?
@@ -66,12 +70,15 @@ java.util.logging.Logger.getLogger("").setLevel(Level.SEVERE);
 === Why does the executable crash with "Cannot locate resource"?
 
 Make sure to only load() models converted to .j3o binary format, not the original Ogre or Wavefront formats. If you load assets from zip files, make sure to ammend the build script to copy them to the build directory.
-+*Learn more:* <<jme3/advanced/asset_manager#,Asset Manager>>
+
+*Learn more:* <<jme3/advanced/asset_manager#,Asset Manager>>
 
 
 === What is java.lang.LinkageError: Version mismatch?
 
-This rare exception shows a message similar to the following: `Exception in thread “LWJGL Renderer Thread java.lang.LinkageError: Version mismatch: jar version is (number), native library version is (another number)`. jME3 needs native libraries (.dll, .jnilib, lib*.so files) to run LWJGL and jBullet. The correct versions of these libraries are included when you install the SDK or download the binaries. However there are circumstances where jME3 cannot determine which copy of the native library it should use: +If you install another application that needs a different version of a native library, and this app globally installs its version over jME3's; or if an old copy of a native library is in your project directory, your home directory, or Java library path, or in the classpath; or if you permanently linked an old copy in your IDE's settings; then Java assumes you prefer these native libraries over the bundled ones, and your jME3 application ends up running with the wrong version. +To fix this, search for .dll (Windows), .jnilib (Mac), and .so (Linux) files for jBullet and LWJGL on your harddrive and in your path and IDE settings, and verify they don't interfere. (If you have other jME  versions installed and linked somehow, the outdated natives may also be in a lwjgl.jar or jbullet.jar file!) 
+This rare exception shows a message similar to the following: `Exception in thread “LWJGL Renderer Thread java.lang.LinkageError: Version mismatch: jar version is (number), native library version is (another number)`. jME3 needs native libraries (.dll, .jnilib, lib*.so files) to run LWJGL and jBullet. The correct versions of these libraries are included when you install the SDK or download the binaries. However there are circumstances where jME3 cannot determine which copy of the native library it should use: +
+If you install another application that needs a different version of a native library, and this app globally installs its version over jME3's; or if an old copy of a native library is in your project directory, your home directory, or Java library path, or in the classpath; or if you permanently linked an old copy in your IDE's settings; then Java assumes you prefer these native libraries over the bundled ones, and your jME3 application ends up running with the wrong version. +
+To fix this, search for .dll (Windows), .jnilib (Mac), and .so (Linux) files for jBullet and LWJGL on your harddrive and in your path and IDE settings, and verify they don't interfere. (If you have other jME  versions installed and linked somehow, the outdated natives may also be in a lwjgl.jar or jbullet.jar file!) 
 
 
 == I want to load my scene
@@ -116,6 +123,7 @@ this.assetManager.registerLocator("town.zip", ZipLocator.class);
 ----
 
 Note that you should not register every single folder containing a texture as the assetmanager will not be able to discern between images with the same name anymore.
+
 *Learn more:* <<jme3/advanced/asset_manager#,Asset Manager>>
 
 
@@ -125,7 +133,9 @@ Follow our best practices for the <<jme3/intermediate/multi-media_asset_pipeline
 You create 3-D models in a 3-D mesh editor, for example Blender, and export it in Ogre Mesh XML (animated objects, scenes) or Wavefront OBJ format (static objects, scenes). 
 You create textures in a graphic editor, for example Gimp, and export them as PNG or JPG.
 You create sounds in an audio editor, for example, Audacity, and export them as WAVE or OGG.
-+*Learn more:* <<jme3/advanced/3d_models#,3D Models>>,  <<jme3/intermediate/multi-media_asset_pipeline#,Multi-Media Asset Pipeline>>, <<sdk/blender#,JME3's blend-to-j3o importer>>; +link:http://blender.org[Download Blender], link:http://en.wikibooks.org/wiki/Blender_3D:_Noob_to_Pro[Blender intro tutorial], link:http://www.ogre3d.org/wiki/index.php/Blender_Exporter[Blender-to-Ogre plugin], link:http://en.wikipedia.org/wiki/Comparison_of_3D_computer_graphics_software#Features[Comparison of 3D graphic software features (Wikipedia)].
+
+*Learn more:* <<jme3/advanced/3d_models#,3D Models>>,  <<jme3/intermediate/multi-media_asset_pipeline#,Multi-Media Asset Pipeline>>, <<sdk/blender#,JME3's blend-to-j3o importer>>; +
+link:http://blender.org[Download Blender], link:http://en.wikibooks.org/wiki/Blender_3D:_Noob_to_Pro[Blender intro tutorial], link:http://www.ogre3d.org/wiki/index.php/Blender_Exporter[Blender-to-Ogre plugin], link:http://en.wikipedia.org/wiki/Comparison_of_3D_computer_graphics_software#Features[Comparison of 3D graphic software features (Wikipedia)].
 
 
 === How do I load a 3-D model into the scene?
@@ -138,14 +148,15 @@ Use the jMonkeyEngine SDK to convert models from Ogre XML or Wavefront OBJ forma
 Spatial ninja = assetManager.loadModel("Models/Ninja/Ninja.j3o");
 ----
 
-*Learn more:* <<jme3/beginner/hello_asset#,Hello Asset>>, <<jme3/advanced/asset_manager#,Asset Manager>>, link:https///github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/asset/AssetManager.java[come.jme3.assets.AssetManager], link/https///github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/scene/Geometry.java[com.jme3.scene.Geometry], <<sdk/model_loader_and_viewer#,jMonkeyEngine SDK j3o converter>>,
-+*Code sample:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/model/TestOgreLoading.java[TestOgreLoading.java], link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/export/TestOgreConvert.java[TestOgreConvert.java].
+*Learn more:* <<jme3/beginner/hello_asset#,Hello Asset>>, <<jme3/advanced/asset_manager#,Asset Manager>>, link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/asset/AssetManager.java[com.jme3.assets.AssetManager], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/scene/Geometry.java[com.jme3.scene.Geometry], <<sdk/model_loader_and_viewer#,jMonkeyEngine SDK j3o converter>>, +
+*Code sample:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/model/TestOgreLoading.java[TestOgreLoading.java], link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/export/TestOgreConvert.java[TestOgreConvert.java].
 
 
 === How do initialize the scene?
 
 Use the simpleInitApp() method in SimpleApplication (or initApp() in Application).
-+*Learn more:* <<jme3/beginner/hello_simpleapplication#,Hello SimpleApplication>>, link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java[SimpleApplication.java].
+
+*Learn more:* <<jme3/beginner/hello_simpleapplication#,Hello SimpleApplication>>, link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java[SimpleApplication.java].
 
 
 == I want to transform objects in the scene
@@ -166,8 +177,9 @@ spatial.setLocalTranslation(1,-3,2.5f); spatial.rotate(0,3.14f,0); spatial.scale
 === How do I make a spatial move by itself?
 
 Change the geometry's translation (position) live in the update loop using setLocalTranslation() for non-physical and applyForce() or setWalkDirection() for physical objects. You can also define and remote-control a spatial's motion using <<jme3/advanced/cinematics#,Cinematics>>, e.g. to record cutscenes, or to implement mobile platforms, elevators, airships, etc.
-+*Learn more:* <<jme3/beginner/hello_main_event_loop#,Hello Loop>>, <<jme3/advanced/update_loop#,Update Loop>>, <<jme3/advanced/custom_controls#,Custom Controls>>, <<jme3/advanced/cinematics#,Cinematics>>
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestBumpModel.java[TestBumpModel.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/model/TestOgreLoading.java[TestOgreLoading.java]
+
+*Learn more:* <<jme3/beginner/hello_main_event_loop#,Hello Loop>>, <<jme3/advanced/update_loop#,Update Loop>>, <<jme3/advanced/custom_controls#,Custom Controls>>, <<jme3/advanced/cinematics#,Cinematics>> +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestBumpModel.java[TestBumpModel.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/model/TestOgreLoading.java[TestOgreLoading.java]
 
 
 === How do I access a named sub-mesh in Model?
@@ -183,7 +195,8 @@ Geometry submesh = (Geometry) model.getChild("door 12");
 === How do I make procedural or custom shapes?
 
 You can programmatically create com.jme3.scene.Mesh'es.
-+*Learn more:* <<jme3/advanced/custom_meshes#,Custom Meshes>>
+
+*Learn more:* <<jme3/advanced/custom_meshes#,Custom Meshes>>
 
 
 == I want to change the surface of objects in the scene
@@ -195,18 +208,14 @@ The most likely reason is the flipping of textures. You may be using the followi
 
 [source,java]
 ----
-
-  material.setTexture("ColorMap", assetManager.loadTexture("myTexture.jpg"));
-
+material.setTexture("ColorMap", assetManager.loadTexture("myTexture.jpg"));
 ----
 
 You can set the boolean value in the constructor of TextureKey to flipped or not flipped. Toggle the boolean to see if it fixes your UV wrapping/texture problem:
 
 [source,java]
 ----
-
-  material.setTexture("ColorMap", this.assetManager.loadTexture(new TextureKey("myTexture.jpg", false)));
-
+material.setTexture("ColorMap", this.assetManager.loadTexture(new TextureKey("myTexture.jpg", false)));
 ----
 
 
@@ -230,15 +239,17 @@ material.getTextureParam("DiffuseMap").getTextureValue().setWrap(WrapMode.Repeat
 === How do I change color or shininess of an material?
 
 Use the AssetManager to load Materials, and change material settings.
-+*Learn more:* <<jme3/beginner/hello_material#,Hello Material>>, <<jme3/intermediate/how_to_use_materials#,How To Use Materials>>, <<jme3/advanced/materials_overview#,Materials Overview>>, <<jme3/advanced/asset_manager#,Asset Manager>>.
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestNormalMapping.java[TestNormalMapping.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/model/shape/TestSphere.java[TestSphere.java].
+
+*Learn more:* <<jme3/beginner/hello_material#,Hello Material>>, <<jme3/intermediate/how_to_use_materials#,How To Use Materials>>, <<jme3/advanced/materials_overview#,Materials Overview>>, <<jme3/advanced/asset_manager#,Asset Manager>>. +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestNormalMapping.java[TestNormalMapping.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/model/shape/TestSphere.java[TestSphere.java].
 
 
 === How do I make a surface wood, stone, metal, etc?
 
 Create Textures as image files. Use the AssetManager to load a Material and use texture mapping for improved looks.
-+*Learn more:* <<jme3/beginner/hello_material#,Hello Material>>, <<jme3/intermediate/how_to_use_materials#,How To Use Materials>>, <<jme3/advanced/materials_overview#,Materials Overview>>, <<jme3/advanced/asset_manager#,Asset Manager>>, link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/asset/AssetManager.java[come.jme3.assets.AssetManager], link:http://wiki.blender.org/index.php/Doc:Manual/Textures/Maps/Bump_and_Normal_Maps[Blender: Creating Bump Maps and Normal Maps]
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestSimpleBumps.java[TestSimpleBumps.java]
+
+*Learn more:* <<jme3/beginner/hello_material#,Hello Material>>, <<jme3/intermediate/how_to_use_materials#,How To Use Materials>>, <<jme3/advanced/materials_overview#,Materials Overview>>, <<jme3/advanced/asset_manager#,Asset Manager>>, link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/asset/AssetManager.java[com.jme3.assets.AssetManager], link:http://wiki.blender.org/index.php/Doc:Manual/Textures/Maps/Bump_and_Normal_Maps[Blender: Creating Bump Maps and Normal Maps] +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/material/TestSimpleBumps.java[TestSimpleBumps.java]
 
 
 === Why are materials too bright, too dark, or flickering?
@@ -249,8 +260,9 @@ If you use a lit material (based on Lighting.j3md) then you must attach a light 
 === How do I make geometries cast a shadow?
 
 Use com.jme3.shadow.BasicShadowRenderer together with com.jme3.light.DirectionalLight, and setShadowMode().
-+*Learn more:* <<jme3/advanced/light_and_shadow#,Light and Shadow>>
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestEverything.java[TestEverything.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/light/TestShadow.java[TestShadow.java]
+
+*Learn more:* <<jme3/advanced/light_and_shadow#,Light and Shadow>> +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestEverything.java[TestEverything.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/light/TestShadow.java[TestShadow.java]
 
 
 === How do I make materials transparent?
@@ -298,12 +310,15 @@ material.getAdditionalRenderState().setWireframe(true);
 
 == I want to control the camera
 
-The default camera `cam` is an instance of the `Camera` class. *Learn more:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/renderer/Camera.java[com.jme3.renderer.Camera]
+The default camera `cam` is an instance of the `Camera` class. 
+
+*Learn more:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/renderer/Camera.java[com.jme3.renderer.Camera]
 
 
 === How do I keep the camera from moving?
 
-*  SimpleApplication activates `flyCam` (an instance of `FlyByCamera`) by default. flyCam causes the camera to move with the mouse and the WASD keys. You can disable flyCam as follows:
+SimpleApplication activates `flyCam` (an instance of `FlyByCamera`) by default. `flyCam` causes the camera to move with the mouse and the WASD keys. You can disable flyCam as follows:
+
 [source,java]
 ----
 flyCam.setEnabled(false);
@@ -313,18 +328,26 @@ flyCam.setEnabled(false);
 
 === How do I switch between third-person and first-person view ?
 
-*  You can activate the FlyBy Cam as a first-person camera. +*Learn more:* <<jme3/beginner/hello_collision#,Hello Collision>>. +*Code sample:*  link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/input/FlyByCam.java[com.jme3.input.FlyByCamera] 
+You can activate the FlyBy Cam as a first-person camera. 
+
 [source,java]
 ----
 flyCam.setEnabled(true);
 ----
 
-*  You can also create a third-person chase cam. +*Learn more:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/input/ChaseCamera.java[com.jme3.input.ChaseCamera] +*Code sample:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/input/TestChaseCamera.java[jme3test/input/TestChaseCamera.java]. 
+*Learn more:* <<jme3/beginner/hello_collision#,Hello Collision>>. +
+*Code sample:*  link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/input/FlyByCam.java[com.jme3.input.FlyByCamera] 
+
+You can also create a third-person chase cam. 
+
 [source,java]
 ----
 flyCam.setEnabled(false);
 chaseCam = new ChaseCamera(cam, spatial, inputManager);
 ----
+
+*Learn more:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/core/com/jme3/input/ChaseCamera.java[com.jme3.input.ChaseCamera] +
+*Code sample:* link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/input/TestChaseCamera.java[jme3test/input/TestChaseCamera.java]. 
 
 
 
@@ -342,40 +365,46 @@ flyCam.setMoveSpeed(50f);
 === How do I implement game logic / game mechanics?
 
 Use Controls to define the behaviour of types of Spatials. Use Application States to implement global behaviour, to group subsets of input handlers or +++<abbr title="Graphical User Interface">GUI</abbr>+++ screens, etc. Use the `simpleUpdate()` and `update()` loops for tests and interactions. Use Cinematics to remote-control objects in scenes.
-+*Learn more:* <<jme3/beginner/hello_main_event_loop#,Hello Loop>>, <<jme3/advanced/update_loop#,Update Loop>>, <<jme3/advanced/custom_controls#,Custom Controls>>, <<jme3/advanced/application_states#,Application States>>, <<jme3/advanced/cinematics#,Cinematics>>
+
+*Learn more:* <<jme3/beginner/hello_main_event_loop#,Hello Loop>>, <<jme3/advanced/update_loop#,Update Loop>>, <<jme3/advanced/custom_controls#,Custom Controls>>, <<jme3/advanced/application_states#,Application States>>, <<jme3/advanced/cinematics#,Cinematics>>
 
 
 === How do I let players interact via keyboard?
 
 Use com.jme3.input.KeyInput and a Input Listener.
-+*Learn more:* <<jme3/beginner/hello_input_system#,Hello Input>>, <<jme3/advanced/input_handling#,Input Handling>>
+
+*Learn more:* <<jme3/beginner/hello_input_system#,Hello Input>>, <<jme3/advanced/input_handling#,Input Handling>>
 
 
 === How do I let players interact by clicking?
 
 Players typically click the mouse to pick up objects, to open doors, to shoot a weapon, etc. Use an Input Listener to respond to mouse clicks, then cast a ray from the player; if it intersects with the bounding volume of a spatial, this is the selected target. The links below contain code samples for both “fixed crosshair picking and “free mouse pointer picking.
-+*Learn more:* <<jme3/beginner/hello_picking#,Hello Picking>>, <<jme3/advanced/mouse_picking#,Mouse Picking>>, <<jme3/advanced/collision_and_intersection#,Collision and Intersection>>, <<jme3/advanced/input_handling#,Input Handling>>, com.jme3.bounding.*, com.jme3.math.Ray, com.jme3.collision.CollisionResults.
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bounding/TestRayCollision.java[TestRayCollision.java]
+
+*Learn more:* <<jme3/beginner/hello_picking#,Hello Picking>>, <<jme3/advanced/mouse_picking#,Mouse Picking>>, <<jme3/advanced/collision_and_intersection#,Collision and Intersection>>, <<jme3/advanced/input_handling#,Input Handling>>, com.jme3.bounding., com.jme3.math.Ray, com.jme3.collision.CollisionResults. +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bounding/TestRayCollision.java[TestRayCollision.java]
 
 
 === How do I animate characters?
 
 Create an animated OgreMesh model with bones in a 3-D mesh editor (e.g. Blender).
-+*Learn more:* com.jme3.animation.*, <<jme3/beginner/hello_animation#,Hello Animation>>, <<jme3/advanced/animation#,Animation>>, link:http://wiki.blender.org/index.php/Doc:Tutorials/Animation/BSoD/Character_Animation[Blender animation tutorial]
-+*Code sample:*  link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/model/anim[animation]
+
+*Learn more:* com.jme3.animation., <<jme3/beginner/hello_animation#,Hello Animation>>, <<jme3/advanced/animation#,Animation>>, link:http://wiki.blender.org/index.php/Doc:Tutorials/Animation/BSoD/Character_Animation[Blender animation tutorial] +
+*Code sample:*  link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/model/anim[animation]
 
 
 === How do I keep players from falling through walls and floors?
 
 Use collision detection. The most common solution is to use jme's physics integration, jBullet.
-+*Learn more:* <<jme3/beginner/hello_collision#,Hello Collision>>, <<jme3/advanced/physics#,Physics>>, com.jme3.bullet.*, CapsuleCollisionShape versus CompoundCollisionShape, CharacterControl versus RigidBodyControl.
+
+*Learn more:* <<jme3/beginner/hello_collision#,Hello Collision>>, <<jme3/advanced/physics#,Physics>>, com.jme3.bullet., CapsuleCollisionShape versus CompoundCollisionShape, CharacterControl versus RigidBodyControl.
 
 
 === How do I make balls/wheels/etc bounce and roll?
 
 Add physics controls to Spatials and give them spherical or cylindrical bounding volumes.
-+*Learn more:* <<jme3/beginner/hello_physics#,Hello Physics>>, <<jme3/advanced/physics#,Physics>>, com.jme3.bounding.*, com.jme3.bullet.collisions, com.jme3.bullet.controls.RigidBodyControl,
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestSimplePhysics.java[TestSimplePhysics.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/bullet[more physics samples]
+
+*Learn more:* <<jme3/beginner/hello_physics#,Hello Physics>>, <<jme3/advanced/physics#,Physics>>, com.jme3.bounding., com.jme3.bullet.collisions, com.jme3.bullet.controls.RigidBodyControl. +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestSimplePhysics.java[TestSimplePhysics.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/bullet[more physics samples]
 
 
 === How do I debug weird Physics behaviour?
@@ -391,21 +420,24 @@ bulletAppState.getPhysicsSpace().enableDebug(assetManager);
 === How do I make a walking character?
 
 You can use jBullet's CharacterControl that locks a physical object upright, so it does not tip over when moving/walking (as tall physical objects are typically wanted to).
-+*Learn more:* CharacterControl
-+Code samples: link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestQ3.java[TestQ3.java] (first-person), link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestPhysicsCharacter.java[TestPhysicsCharacter.java] (third-person)
+
+*Learn more:* CharacterControl +
+*Code samples:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestQ3.java[TestQ3.java] (first-person), link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestPhysicsCharacter.java[TestPhysicsCharacter.java] (third-person)
 
 
 === How do I steer vehicles?
 
 Use a VehicleControl that supports suspension behavior.
-+*Learn more:* <<jme3/advanced/vehicles#,Vehicles>>, com.jme3.bullet.*, VehicleControl
-+Code samples: link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java[TestFancyCar.java], (Press HUJK keys to steer, spacebar to jump.)
+
+*Learn more:* <<jme3/advanced/vehicles#,Vehicles>>, com.jme3.bullet., VehicleControl +
+Code samples: link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java[TestFancyCar.java], (Press HUJK keys to steer, spacebar to jump.)
 
 
 === Can objects swing like a pendulums, chains, ropebridges?
 
 Use a PhysicsControl's hinges and joints.
-+*Learn more:* <<jme3/advanced/hinges_and_joints#,Hinges and Joints>>, com.jme3.bullet.joints.PhysicsHingeJoint,
+
+*Learn more:* <<jme3/advanced/hinges_and_joints#,Hinges and Joints>>, com.jme3.bullet.joints.PhysicsHingeJoint,
 link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/bullet/TestPhysicsHingeJoint.java[TestPhysicsHingeJoint.java] (Press HK keys to turn, spacebar to swing.)
 
 
@@ -415,7 +447,8 @@ link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/sr
 === What are these FPS/Objects/Vertices/Triangles statistics?
 
 At the bottom left of every default SimpleGame, you see the <<jme3/advanced/statsview#,StatsView>> and the FPS (frames per seconds) view. These views provide you with extra information during the development phase. For example, if you notice the object count is increasing and the FPS is decreasing, then you know that your code attaches too many objects and does not detach enough of them again (maybe a loop gone wild?).
-+*Learn more:* <<jme3/advanced/statsview#,StatsView>>
+
+*Learn more:* <<jme3/advanced/statsview#,StatsView>>
 
 
 === How do I get rid of the FPS/Objects statistics?
@@ -432,22 +465,25 @@ setDisplayStatView(false); // to hide the statistics
 === How do I display score, health, mini-maps, status icons?
 
 Attach text and pictures to the orthogonal `guiNode` to create a heads-up display (link:http://en.wikipedia.org/wiki/HUD_%28video_gaming%29[HUD]).
-+*Learn more:* <<jme3/advanced/hud#,HUD>>, com.jme3.font.*, com.jme3.ui.Picture, guiNode.attachChild()
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/gui/TestOrtho.java[TestOrtho.java], 
-link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/gui/TestBitmapFont.java[TestBitmapFont.java] |
+
+*Learn more:* <<jme3/advanced/hud#,HUD>>, com.jme3.font., com.jme3.ui.Picture, guiNode.attachChild() +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/gui/TestOrtho.java[TestOrtho.java], 
+link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/gui/TestBitmapFont.java[TestBitmapFont.java] 
 
 
 === How do I display buttons and UI controls?
 
 You may want to display buttons to let the player switch between the game, settings screen, and score screens. For buttons and other more advanced UI controls, jME supports the Nifty +++<abbr title="Graphical User Interface">GUI</abbr>+++ library.
-+*Learn more:* <<jme3/advanced/nifty_gui#,Nifty GUI>>
-+Sample Code: link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyGui.java[TestNiftyGui.java]
+
+*Learn more:* <<jme3/advanced/nifty_gui#,Nifty GUI>> +
+Sample Code: link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyGui.java[TestNiftyGui.java]
 
 
 === How do i display a loading screen?
 
 Instead of having a frozen frame while your games loads, you can have a loading screen while it loads. 
-+*Learn more:* <<jme3/advanced/loading_screen#,Loading screen>>
+
+*Learn more:* <<jme3/advanced/loading_screen#,Loading screen>>
 
 
 == Nifty GUI
@@ -478,38 +514,43 @@ link:http://nifty-gui.svn.sourceforge.net/viewvc/nifty-gui/nifty-examples/trunk/
 
 === How do I play sounds and noises?
 
-Use AudioRenderer, Listener, and AudioNode from com.jme3.audio.*.
-+*Learn more:* <<jme3/beginner/hello_audio#,Hello Audio>>, <<jme3/advanced/audio#,Audio>>
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/audio[audio]
+Use AudioRenderer, Listener, and AudioNode from com.jme3.audio..
+
+*Learn more:* <<jme3/beginner/hello_audio#,Hello Audio>>, <<jme3/advanced/audio#,Audio>> +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/tree/master/jme3-examples/src/main/java/jme3test/audio[audio]
 
 
 === How do I make fire, smoke, explosions, swarms, magic spells?
 
 For swarm like effects you use particle emitters.
-+*Learn more:* <<jme3/beginner/hello_effects#,Hello Effects>>, <<jme3/advanced/particle_emitters#,Particle Emitters>>, <<jme3/advanced/bloom_and_glow#,Bloom and Glow>>, <<jme3/advanced/effects_overview#,Effects Overview>>, com.jme3.effect.EmitterSphereShape, com.jme3.effect.ParticleEmitter
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestExplosionEffect.java[TestExplosionEffect.java], 
+
+*Learn more:* <<jme3/beginner/hello_effects#,Hello Effects>>, <<jme3/advanced/particle_emitters#,Particle Emitters>>, <<jme3/advanced/bloom_and_glow#,Bloom and Glow>>, <<jme3/advanced/effects_overview#,Effects Overview>>, com.jme3.effect.EmitterSphereShape, com.jme3.effect.ParticleEmitter +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestExplosionEffect.java[TestExplosionEffect.java], 
 link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestMovingParticle.java[TestMovingParticle.java],
 link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/effect/TestSoftParticles.java[TestSoftParticle.java]
 
 
 === How do I make water, waves, reflections?
 
-Use a special post-processor renderer from com.jme3.water.*.
-+*Learn more:* <<jme3/advanced/water#,Water>>, <<jme3/advanced/post-processor_water#,Post-Processor Water>>
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestSimpleWater.java[TestSimpleWater.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestSceneWater.java[TestSceneWater.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestPostWaterLake.java[TestPostWaterLake.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestPostWater.java[TestPostWater.java]
+Use a special post-processor renderer from com.jme3.water..
+
+*Learn more:* <<jme3/advanced/water#,Water>>, <<jme3/advanced/post-processor_water#,Post-Processor Water>> +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestSimpleWater.java[TestSimpleWater.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestSceneWater.java[TestSceneWater.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestPostWaterLake.java[TestPostWaterLake.java], link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/water/TestPostWater.java[TestPostWater.java]
 
 
 === How do I make fog, bloom, blur, light scattering?
 
-Use special post-processor renderers from com.jme3.post.*.
-+*Learn more:* <<jme3/advanced/effects_overview#,effects_overview>>
+Use special post-processor renderers from com.jme3.post..
+
+*Learn more:* <<jme3/advanced/effects_overview#,effects_overview>>
 
 
 === How do I generate a terrain?
 
-Use com.jme3.terrain.*. The JMonkeyEngine also provides you with a Terrain Editor plugin.
-+*Learn more:* <<jme3/beginner/hello_terrain#,Hello Terrain>>, <<jme3/advanced/terrain#,Terrain>>, <<sdk/terrain_editor#,Terrain Editor>>
-+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java[TerrainTest.java]
+Use com.jme3.terrain.. The JMonkeyEngine also provides you with a Terrain Editor plugin.
+
+*Learn more:* <<jme3/beginner/hello_terrain#,Hello Terrain>>, <<jme3/advanced/terrain#,Terrain>>, <<sdk/terrain_editor#,Terrain Editor>> +
+*Code sample:* link:https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java[TerrainTest.java]
 
 
 === How do I make a sky?


### PR DESCRIPTION
This update is almost entirely adding a space between a paragraphs end and the "Learn More:" line. Current AsciiDoc formatting says that when using the plus(+) sign to generate a new line you place the plus(+) at the end of the line *prior* to the new line. This was not the case for most of the doc so I modified it to be so. This was causing broken new lines in IE. In the process I fixed a couple broken links that were formatted wrong and removed some stray asterisks(*) that were not accomplishing what was intended by whomever placed them. Rather than fix them for intended use, I just removed them for now. Also removed a stray vertical bar(|). Applying the correct use of plus(+) as stated by the docs completely fixed all problems in IE, as for other browsers, I do not know.