### PR TITLE
Update file_types.adoc

### DIFF
--- a/src/docs/asciidoc/jme3/intermediate/file_types.adoc
+++ b/src/docs/asciidoc/jme3/intermediate/file_types.adoc
@@ -9,7 +9,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 
 == jMonkeyEngine3 File Formats
-[cols="3", options="header"]
+[cols="20,50,30", options="header"]
 |===
 
 a|Suffix
@@ -17,20 +17,24 @@ a|Usage
 a|Learn more
 
 l|.j3o
-a|Binary 3D model or scene. At the latest from the Beta release of your game on, you should convert all models to .j3o format. +During alpha and earlier development phases (when models still change a lot) you can alternatively load OgreXML/OBJ models directly.
+a|Binary 3D model or scene. At the latest from the Beta release of your game on, you should convert all models to .j3o format. +
+During alpha and earlier development phases (when models still change a lot) you can alternatively load OgreXML/OBJ models directly.
 a|<<sdk/model_loader_and_viewer#,Model Loader and Viewer>> 
 
 l|.j3m
 a|A custom Material. You can create a .j3m file to store a Material configuration for a Geometry (e.g. 3D model).
-a|<<jme3/advanced/materials_overview#,Materials Overview>> +<<sdk/material_editing#,Material Editing>> 
+a|<<jme3/advanced/materials_overview#,Materials Overview>> +
+<<sdk/material_editing#,Material Editing>> 
 
 l|.j3md
-a|A Material definition. These are pre-defined templates for shader-based Materials. +Each custom .j3m Material is based on a material definition. Advanced users can create their own material definitions. 
+a|A Material definition. These are pre-defined templates for shader-based Materials. +
+Each custom .j3m Material is based on a material definition. Advanced users can create their own material definitions. 
 a| <<jme3/advanced/materials_overview#,Materials Overview>> 
 
 l|.j3f
 a|A custom post-processor filter configuration. You can create a .j3f file to store a FilterPostProcessor with a set of preconfigured filters. 
-a| <<sdk/filters#,Filters>> +<<jme3/advanced/effects_overview#,Effects Overview>> 
+a| <<sdk/filters#,Filters>> +
+<<jme3/advanced/effects_overview#,Effects Overview>> 
 
 |===
 


### PR DESCRIPTION
Corrected broken new lines where plus(+) was not on previous line as is called for by docs. Formatted first tables column widths to be 20, 50, 30 rather than all equal. Center column contains larger text requirements.