### PR TITLE
Update matrix.adoc

### DIFF
--- a/src/docs/asciidoc/jme3/matrix.adoc
+++ b/src/docs/asciidoc/jme3/matrix.adoc
@@ -10,8 +10,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 == Matrix
 
-See link:http://javadoc.jmonkeyengine.org/com/jme3/math/Matrix3f.html[Javadoc of Matrix3f]+
-and link:http://javadoc.jmonkeyengine.org/com/jme/math/Matrix4f.html[Javadoc of Matrix4f]
+See link:http://javadoc.jmonkeyengine.org/com/jme3/math/Matrix3f.html[Javadoc of Matrix3f] and link:http://javadoc.jmonkeyengine.org/com/jme3/math/Matrix4f.html[Javadoc of Matrix4f]
 
 
 === Definition


### PR DESCRIPTION
Fixed broken javadoc link and removed unnecessary new line break from link.