### PR TITLE
Update physics_listeners.adoc

### DIFF
--- a/src/docs/asciidoc/jme3/advanced/physics_listeners.adoc
+++ b/src/docs/asciidoc/jme3/advanced/physics_listeners.adoc
@@ -170,7 +170,8 @@ The PhysicsCollisionEvent `event` gives you access to detailed information about
 <a|Method                        
 a|Purpose
 
-<a| getObjectA() +getObjectB()     
+<a| getObjectA() +
+getObjectB()     
 a| The two participants in the collision. You cannot know in advance whether some node will be recorded as A or B, you always have to consider both cases. 
 
 <a| getAppliedImpulse()          


### PR DESCRIPTION
Fixed broken new line in first cell of the "Reading details from a collision event" table.