### PR TITLE
Update jme3.adoc

### DIFF
--- a/src/docs/asciidoc/jme3.adoc
+++ b/src/docs/asciidoc/jme3.adoc
@@ -41,7 +41,6 @@ image::jme3/beginner/beginner-physics.png[beginner-physics.png,with="360",height
 
 See also: <<sdk/sample_code#,Trouble running the samples>>?
 
-For more help getting started, check out this tuts+ guide on “link:http://gamedevelopment.tutsplus.com/articles/how-to-learn-jmonkeyengine-3--gamedev-10479[ How to learn jMonkeyEngine 3].
 
 
 == Documentation for Intermediate Users
@@ -77,7 +76,7 @@ Now that you understood the basics, let's put it all together. The following int
 
 *Game Tutorials*
 
-*  link:http://gamedevelopment.tutsplus.com/series/cross-platform-vector-shooter-jmonkeyengine--gamedev-13757[Neon Vector Shooter tutorial on Tuts+]
+*  link:https://gamedevelopment.tutsplus.com/series/cross-platform-vector-shooter-jmonkeyengine--gamedev-13757[Neon Vector Shooter tutorial on Tuts+]
 
 *Video Use Case Tutorials*
 - Note these videos use alpha features only available in the next release


### PR DESCRIPTION
Removed link to 
For more help getting started, check out this tuts+ guide on “ How to learn jMonkeyEngine 3.
because the target of the link is badly outdated and full of broken links.
Fixed other broken tut+ link. They now use secure link https.