### PR TITLE
Added a note to include that nifty isn't always loaded and how to fix it

### DIFF
--- a/src/docs/asciidoc/jme3/advanced/nifty_gui_overlay.adoc
+++ b/src/docs/asciidoc/jme3/advanced/nifty_gui_overlay.adoc
@@ -52,6 +52,7 @@ flyCam.setDragToRotate(true);
 
 Currently you do not have a ScreenController – we will create one in the next exercise. As soon  as you have a screen controller, you will use the commented variant of the XML loading method:
 
+Note that the nifty library is not always loaded when you create a project, causing an "cannot find symbol" error. To solve this right click your project and then go to properties->libraries and click on "add library". Then select jme3-niftygui and click import.
 [source,java]
 ----
 nifty.fromXml("Interface/helloworld.xml", "start", new MySettingsScreen());


### PR DESCRIPTION
I basically ran across the above problem and couldn't figure out what was wrong until someone pointed out that the nifty library was probably not loaded, something which surprised me and I imaging would surprise others as well.

There may be a better place to put this note but this is where I got stuck.
There is also a dead link that should go to some sample code but I am not sure what to point it to now.
The current link that I am talking about goes to link:http://code.google.com/p/jmonkeyengine/source/browse/trunk/engine/src/test/jme3test/niftygui/TestNiftyGui.java[TestNiftyGui.java]