### PR TITLE
Update grooy doc location

### DIFF
--- a/src/docs/asciidoc/jme3/advanced/atom_framework/design.adoc
+++ b/src/docs/asciidoc/jme3/advanced/atom_framework/design.adoc
@@ -294,7 +294,7 @@ Atom in its core try to be polymorphism (polygot programming), to suite with OOP
 
 Because AtomScripting and others use Groovy, so it inherit (a lot of) polygot capacity from Groovy.
 
-Read: link:http://groovy.codehaus.org/Polyglot+Programming+with+Groovy[http://groovy.codehaus.org/Polyglot+Programming+with+Groovy]
+Read: link:http://groovy-lang.org/Polyglot+Programming+with+Groovy[http://groovy-lang.org/Polyglot+Programming+with+Groovy]
 
 
 ==== Functional reactive programming

--- a/src/docs/asciidoc/jme3/advanced/atom_framework/design/patterns.adoc
+++ b/src/docs/asciidoc/jme3/advanced/atom_framework/design/patterns.adoc
@@ -44,7 +44,7 @@ image::wiki/groovy-logo.png[200,width="",height="",align="right"]
 is an agile and dynamic language for the Java Virtual Machine
 builds upon the strengths of Java but has additional power features inspired by languages like Python, Ruby and Smalltalk
 
-link:http://groovy.codehaus.org/[http://groovy.codehaus.org/]
+link:http://groovy-lang.org/[http://groovy-lang.org/]
 
 
 [TIP]

--- a/src/docs/asciidoc/jme3/advanced/atom_framework/docs.adoc
+++ b/src/docs/asciidoc/jme3/advanced/atom_framework/docs.adoc
@@ -69,7 +69,7 @@ AtomCore (pure Java) supports:
 
 Because AtomScripting and others use Groovy, so it inherit (a lot of) polygot capacity from Groovy.
 
-Read: link:http://groovy.codehaus.org/Polyglot+Programming+with+Groovy[http://groovy.codehaus.org/Polyglot+Programming+with+Groovy]
+Read: link:http://groovy-lang.org/Polyglot+Programming+with+Groovy[http://groovy-lang.org/Polyglot+Programming+with+Groovy]
 
 
 === How can I structure my code?

--- a/src/docs/asciidoc/jme3/scripting.adoc
+++ b/src/docs/asciidoc/jme3/scripting.adoc
@@ -94,7 +94,7 @@ image::wiki/groovy-logo.png[200,width="",height="",align="right"]
 is an agile and dynamic language for the Java Virtual Machine
 builds upon the strengths of Java but has additional power features inspired by languages like Python, Ruby and Smalltalk
 
-link:http://groovy.codehaus.org/[http://groovy.codehaus.org/]
+link:http://groovy-lang.org/[http://groovy-lang.org/]
 
 
 === Highlight
@@ -117,7 +117,7 @@ link:http://en.wikipedia.org/wiki/Groovy_%28programming_language%29[http://en.wi
 
 If you used JMP to code your game (I don’t know about Eclipse users, sorry). Go to Update Center to install Groovy plugin, then download the lastest Groovy (ver2.1) and wrap it as a Library. You are ready for the adventure!
 
-link:http://groovy.codehaus.org/Download?nc[http://groovy.codehaus.org/Download?nc]
+link:http://groovy-lang.org/Download?nc[http://groovy-lang.org/Download?nc]
 
 
 === WHAT CAN BE SCRIPT
@@ -244,7 +244,7 @@ Some of the example above will be include in this post or in my AtomScript proje
 
 Here are some website that you can find a lot of examples from simple to complicated tasks:
 
-link:http://groovy.codehaus.org/Cookbook+Examples[http://groovy.codehaus.org/Cookbook+Examples]
+link:http://groovy-lang.org/Cookbook+Examples[http://groovy-lang.org/Cookbook+Examples]
 
 link:http://www.groovyexamples.org/[http://www.groovyexamples.org/]
 
@@ -278,7 +278,7 @@ GOTO <<jme3/scripting/gpars_usecases#,gpars_usecases>>
 
 [TIP]
 ====
-First I recommend all who don't know much about Groovy read this official documentation link:http://groovy.codehaus.org/Embedding+Groovy[http://groovy.codehaus.org/Embedding+Groovy]
+First I recommend all who don't know much about Groovy read this official documentation link:http://groovy-lang.org/Embedding+Groovy[http://groovy-lang.org/Embedding+Groovy]
 ====
 
 

--- a/src/docs/asciidoc/jme3/scripting/groovy_learn.adoc
+++ b/src/docs/asciidoc/jme3/scripting/groovy_learn.adoc
@@ -39,13 +39,13 @@ We will learn about it later.
 
 ==== Official syntax description
 
-link:http://groovy.codehaus.org/For+those+new+to+both+Java+and+Groovy[http://groovy.codehaus.org/For+those+new+to+both+Java+and+Groovy]
+link:http://groovy-lang.org/For+those+new+to+both+Java+and+Groovy[http://groovy-lang.org/For+those+new+to+both+Java+and+Groovy]
 
-link:http://groovy.codehaus.org/User+Guide[http://groovy.codehaus.org/User+Guide]
+link:http://groovy-lang.org/User+Guide[http://groovy-lang.org/User+Guide]
 
-link:http://groovy.codehaus.org/Logical+Branching[http://groovy.codehaus.org/Logical+Branching]
+link:http://groovy-lang.org/Logical+Branching[http://groovy-lang.org/Logical+Branching]
 
-link:http://groovy.codehaus.org/Looping[http://groovy.codehaus.org/Looping]
+link:http://groovy-lang.org/Looping[http://groovy-lang.org/Looping]
 
 For your overview, I will introduce the most important syntax of the language:
 
@@ -77,9 +77,9 @@ Beside with elegant syntax, Groovy has features you always wish that Java have, 
 
 Read more about it here:
 
-link:http://groovy.codehaus.org/Closures[http://groovy.codehaus.org/Closures]
-link:http://groovy.codehaus.org/Closures+-+Informal+Guide[http://groovy.codehaus.org/Closures+-+Informal+Guide]
-link:http://groovy.codehaus.org/Closures+-+Formal+Definition[http://groovy.codehaus.org/Closures+-+Formal+Definition]
+link:http://groovy-lang.org/Closures[http://groovy-lang.org/Closures]
+link:http://groovy-lang.org/Closures+-+Informal+Guide[http://groovy-lang.org/Closures+-+Informal+Guide]
+link:http://groovy-lang.org/Closures+-+Formal+Definition[http://groovy-lang.org/Closures+-+Formal+Definition]
 
 What is a *Closure*?
 
@@ -101,7 +101,7 @@ Note that in the above example, “hello! is printed when the Closure is called,
 
 === and Gotchas
 
-link:http://groovy.codehaus.org/Differences+from+Java[http://groovy.codehaus.org/Differences+from+Java]
+link:http://groovy-lang.org/Differences+from+Java[http://groovy-lang.org/Differences+from+Java]
 
 
 === Meta-programming


### PR DESCRIPTION
http://groovy.codehaus.org no longer works, so simply replacing with the correct path (http://groovy-lang.org)