### PR TITLE
Fix travis exceptions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 2.2
+  - jruby
+  - 2.0.0-p247
+
+# safelist
+branches:
+  only:
+  - master


### PR DESCRIPTION
Build config file is required via repository settings, but config is empty.