### PR TITLE
Saving/Loading Settings Correction

### DIFF
--- a/src/docs/asciidoc/jme3/intermediate/appsettings.adoc
+++ b/src/docs/asciidoc/jme3/intermediate/appsettings.adoc
@@ -226,27 +226,29 @@ a|Restart()ing a running game restarts the game context and applies the updated 
 
 == Saving and Loading Settings
 
-An AppSettings object also supports the following methods to save your settings under a unique key (in this example "`com/foo/MyCoolGame3`"):
+An AppSettings object also supports the following methods to save your settings under a unique key (in this example "`com/foo/mycoolgame3`"):
 
-*  Use `settings.save("com/foo/MyCoolGame3")` to save your settings via standard java.io serialization.
-*  Use `settings.load("com/foo/MyCoolGame3")` to load your settings.
+*  Use `settings.save("com/foo/mycoolgame3")` to save your settings via standard java.io serialization.
+*  Use `settings.load("com/foo/mycoolgame3")` to load your settings.
 *  Use `settings2.copyFrom(settings)` to copy a settings object.
 
 Usage:
 
-Provide the unique name of your jME3 application as the String argument. For example `com/foo/MyCoolGame3`.
+Provide the unique name of your jME3 application as the String argument. For example `com/foo/mycoolgame3`.
 
 [source,java]
 ----
 
-    try { settings.save("com/foo/MyCoolGame3"); }
+    try { settings.save("com/foo/mycoolgame3"); }
     catch (BackingStoreException ex) { /** could not save settings */ }
 
 ----
 
 *  On Windows, the preferences are saved under the following registry key: +
-`HKEY_CURRENT_USER\Software\JavaSoft\Prefs\com\foo\MyCoolGame3`
+`HKEY_CURRENT_USER\Software\JavaSoft\Prefs\com\foo\mycoolgame3`
 *  On Linux, the preferences are saved in an XML file under: +
-`$HOME/.java/.userPrefs/com/foo/MyCoolGame3`
+`$HOME/.java/.userPrefs/com/foo/mycoolgame3`
 *  On Mac +++<abbr title="Operating System">OS</abbr>+++ X, the preferences are saved as XML file under: +
-`$HOME/Library/Preferences/com.foo.MyCoolGame3.plist`
+`$HOME/Library/Preferences/com.foo.mycoolgame3.plist`
+
+CAUTION: Due to a current bug and inconsistent behavior observed related to the preferences save location, to ensure correct behavior, save() and load() should only use forward slashes (/) and must be all lowercase. More information can be found link:https://github.com/jMonkeyEngine/jmonkeyengine/issues/1161[here].

--- a/src/docs/asciidoc/jme3/intermediate/appsettings.adoc
+++ b/src/docs/asciidoc/jme3/intermediate/appsettings.adoc
@@ -226,20 +226,20 @@ a|Restart()ing a running game restarts the game context and applies the updated 
 
 == Saving and Loading Settings
 
-An AppSettings object also supports the following methods to save your settings under a unique key (in this example "`com.foo.MyCoolGame3`"):
+An AppSettings object also supports the following methods to save your settings under a unique key (in this example "`com/foo/MyCoolGame3`"):
 
-*  Use `settings.save("com.foo.MyCoolGame3")` to save your settings via standard java.io serialization.
-*  Use `settings.load("com.foo.MyCoolGame3")` to load your settings.
+*  Use `settings.save("com/foo/MyCoolGame3")` to save your settings via standard java.io serialization.
+*  Use `settings.load("com/foo/MyCoolGame3")` to load your settings.
 *  Use `settings2.copyFrom(settings)` to copy a settings object.
 
 Usage:
 
-Provide the unique name of your jME3 application as the String argument. For example `com.foo.MyCoolGame3`.
+Provide the unique name of your jME3 application as the String argument. For example `com/foo/MyCoolGame3`.
 
 [source,java]
 ----
 
-    try { settings.save("com.foo.MyCoolGame3"); }
+    try { settings.save("com/foo/MyCoolGame3"); }
     catch (BackingStoreException ex) { /** could not save settings */ }
 
 ----


### PR DESCRIPTION
When a "." is used within these keys, code executed by Preferences.userRoot().node() ends up mangling the directory structure and you end up with preferences stored in a directory name like "HOME/.java/.userPrefs/_!'o!^@"v!'4!aw"l!(k![@"u!" instead of the structure the documentation expects. 

Basically Preferences.userRoot().node() expects slashes, rather than periods. I've tested this locally on Linux and switching to using / resolves that issue and creates proper directory structures. I haven't tested on Windows or Mac, so I don't know if they behave differently.  I only noticed this after finding a large number of these long, mangled directory names accumulating inside my own .userPrefs directory.