### PR TITLE
Change jcenter url to https for Maven

### DIFF
--- a/docs/modules/ROOT/pages/jme3/maven.adoc
+++ b/docs/modules/ROOT/pages/jme3/maven.adoc
@@ -89,7 +89,7 @@ dependencies {
   <repositories>
     <repository>
       <id>jcenter</id>
-      <url>http://jcenter.bintray.com</url>
+      <url>https://jcenter.bintray.com</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
As of 2020, jcenter.bintray.com only accepts https connections. (Otherwise fails with a 403 status code)