### PR TITLE
texture/anisotropic_filtering.doc: correct errors, improve code samples

### DIFF
--- a/docs/modules/core/pages/texture/anisotropic_filtering.adoc
+++ b/docs/modules/core/pages/texture/anisotropic_filtering.adoc
@@ -1,44 +1,54 @@
 = anisotropic_filtering
-:revnumber: 2.0
-:revdate: 2020/07/23
+:revnumber: 2.1
+:revdate: 2020/09/09
 
 
 
 == Anisotropic Filtering for Textures
 
-Anisotropic Filtering is very important for Desktop Games and their textures. Most games use AnisotropicFiltering = 4/8/16. It sharpens your textures under different Angle View.
-Anisotropy makes a performance draw back about 10-40 fps, but the result looks much better.
+Anisotropic filtering is important for desktop games.
+It sharpens textures that are viewed from an oblique angle.
+Anisotropy has a performance impact, but the results look much better.
 
-See Example: link:http://i.imgur.com/0yiv9.jpg[http://i.imgur.com/0yiv9.jpg]
+For example: link:http://i.imgur.com/0yiv9.jpg[http://i.imgur.com/0yiv9.jpg]
 
 image::texture/anisotropy_example_mifth_01.jpg[anisotropy_example_mifth_01.jpg,width="360",height="900",align="right"]
 
+NOTE: JME supports anisotropic filtering only on desktop platforms,
+      not on mobile devices.
 
-JME has DEFAULT AnisotropicFiltering = 0. So, if you make a game for Windows/Linux/Mac.. you need to set the Anisotropic Filtering more than 0.
-
-Example how to set AnisotropicFiltering = 8 for all textures:
+The maximum possible degree of anisotropy depends on the graphics hardware.
+To determine this limit, simply query the renderer:
 
 [source,java]
 ----
+Renderer renderer = application.getRenderer();
+int maxDegree = renderer.getLimits().get(Limits.TextureAnisotropy);
+----
 
-        AssetEventListener asl = new AssetEventListener() {
-            public void assetLoaded(AssetKey key) {
-//                throw new UnsupportedOperationException("Not supported yet.");
-            }
+By default, anisotropic filtering is disabled.
+To enable it for a specific texture, specify the desired degree of anisotropy
+in the key used to load the texture.
+For instance, to load a texture with 8x anisotropic filtering:
 
-            public void assetRequested(AssetKey key) {
-                if (key.getExtension().equals("png") || key.getExtension().equals("jpg") || key.getExtension().equals("dds")) {
-                    System.out.println(key.getExtension());
-                    TextureKey tkey = (TextureKey) key;
-                    tkey.setAnisotropy(8);
-                }
-            }
+[source,java]
+----
+TextureKey key = new TextureKey(assetPath);
+int degree = 8;
+key.setAnisotropy(degree);
+Texture texture = assetManager.loadTexture(key);
+----
 
-            public void assetDependencyNotFound(AssetKey parentKey, AssetKey dependentAssetKey) {
-//                throw new UnsupportedOperationException("Not supported yet.");
-            }
-        };
+* Specifying `degree = 1` disables anisotropic filtering for the texture.
+* Specifying `degree = 0` (the default) causes the loader
+  to apply JME's global setting.
 
-        assetManager.addAssetEventListener(asl);
+The global setting defaults to 1, but this can be changed.
+For instance, to set the global default to 4x filtering:
 
+[source, java]
+----
+Renderer renderer = application.getRenderer();
+int degree = 4;
+renderer.setDefaultAnisotropicFilter(degree);
 ----


### PR DESCRIPTION
The current documentation for anisotropic filtering omits a couple important details:
 1. hardware limits
 2. the JME global default

The claimed performance impact of "10-40 fps" is meaningless. The FPS impact will depend on many factors, so I removed that claim.

Using an `AssetEventListener` to apply anisotropic filtering is unnecessarily complicated, so I removed that code sample. 