### PR TITLE
Fix spelling mistake in animation.adoc

### DIFF
--- a/docs/modules/core/pages/animation/animation.adoc
+++ b/docs/modules/core/pages/animation/animation.adoc
@@ -90,7 +90,7 @@ skeletonControl = player.getControl(SkeletonControl.class);
 
 ----
 
-.Control rsides somewhere other than main node
+.Control resides somewhere other than main node
 [source,java]
 ----
 player.depthFirstTraversal(new SceneGraphVisitorAdapter() {


### PR DESCRIPTION
In the section about the Skeleton Control, it says "Control **rsides** somewhere other than main node", which has "**resides**" misspelled, which is changed to "Control **resides** somewhere other than main node"