### PR TITLE
maven.adoc: update for JME v3.4 and JCenter sunset

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/maven.adoc
+++ b/docs/modules/ROOT/pages/getting-started/maven.adoc
@@ -1,56 +1,43 @@
 = Maven Artifacts
-:revnumber: 2.0
-:revdate: 2020/07/25
+:revnumber: 2.1
+:revdate: 2021/05/05
 
 
-You can use jME3 with maven compatible build systems.
+You can build jME3 projects using Maven-compatible build systems.
 
+Artifacts for recent releases are available from the Maven Central Repository:
 
-== jME3.3
-
-Artifacts for jME 3.1, jME 3.2, and jME 3.3 releases are available in repositories :
-
-* link:https://jcenter.bintray.com/org/jmonkeyengine/[JCenter]
-* link:https://bintray.com/jmonkeyengine/org.jmonkeyengine[Bintray repo: org.jmonkeyengine] every artifact of the group org.jmonkeyengine (same as jcenter + few artifacts not eligible for jcenter), click on the `SET ME UP` button to view instruction for Gradle, Maven,...
+* link:https://search.maven.org/search?q=org.jmonkeyengine
 
 The group id for all jME3 libraries is `org.jmonkeyengine`.
 
-The following artifacts are currently available (version `3.3.2-stable`):
+The following artifacts are available:
 
-*  jme3-android-native - Native libraries needed for Android
-*  jme3-android - Android renderer for jME3
-*  jme3-blender - Blender file loader, only works on desktop renderers
-*  jme3-bullet-native-android - Native libraries needed for bullet (not jbullet) on android (beta)
-*  jme3-bullet-native - Native libraries needed for bullet (not jbullet) on desktop (beta)
-*  jme3-bullet - Physics support using native bullet, needs jme3-bullet-native or jme3-bullet-native-android (beta)
-+
-NOTE: *Only one version of jme3-jbullet OR jme3-bullet with a single "`natives`" library can be used.*
+*  jme3-android - Android platform support
+*  jme3-android-native - Native libraries for Android platforms
+*  jme3-core - Core functionality needed in all jME3 projects
+*  jme3-desktop - Desktop platform support (Windows, Linux, and macOS)
+*  jme3-effects - Extra special effects, including water and other post filters
+*  jme3-examples - Sample/test/tutorial apps
+*  jme3-ios - iOS platform support
+*  jme3-jbullet - Physics library using jBullet
+*  jme3-jogg - Asset loader for https://www.xiph.org/ogg/[the Ogg audio format]
+*  jme3-lwjgl - Interface to LWJGL v2
+*  jme3-lwjgl3 - Interface to LWJGL v3
+*  jme3-networking - Networking library (aka SpiderMonkey)
+*  jme3-niftygui - NiftyGUI support for jME3
+*  jme3-plugins - Extra asset loaders for https://www.khronos.org/gltf/[glTF], https://www.ogre3d.org/[Ogre] XML, and jME XML formats
+*  jme3-terrain - Terrain library (aka TerraMonkey)
+*  jme3-testdata - Assets used in jme3-examples
+*  jme3-vr - Support for virtual reality
 
-*  jme3-core - Core libraries needed for all jME3 projects
-*  jme3-desktop - Parts of the jME3 +++<abbr title="Application Programming Interface">API</abbr>+++ that are only compatible with desktop renderers, needed for image loading on desktop
-*  jme3-effects - Effects libraries for water and other post filters
-*  jme3-jogg - Loader for jogg audio files
-*  jme3-jogl - JOGL based renderer (optional replacement for lwjgl / lwjgl3)
-*  jme3-lwjgl - Desktop renderer for jME3
-*  jme3-lwjgl3 - NEW since jME3.1! LWJGL3-based desktop renderer for jME3 (beta)
-*  jme3-networking - jME3 networking libraries (aka spidermonkey)
-*  jme3-niftygui - NiftyGUI support for jME3 (Not available in JCenter)
-*  jme3-plugins - Loader plugins for OgreXML and jME-XML
-*  jme3-terrain - Terrain generation +++<abbr title="Application Programming Interface">API</abbr>+++
-*  jme3-jbullet - Physics support using jbullet (desktop only, not available in JCenter)
-+
-NOTE: *Only one version of jme3-jbullet OR jme3-bullet with a single "`natives`" library can be used.*
-
-*  jme3-ios - iOS renderer for jME3 (Not available in JCenter)
-*  jme3-vr - New since jME3.2! Support for virtual reality. (Not available in JCenter)
-
-For a basic desktop application to work you need to import at least
+For a basic desktop application, you need at least:
 
 *  jme3-core
 *  jme3-desktop
 *  jme3-lwjgl OR jme3-lwjgl3
 
-For a basic android application to work you need to import at least
+For a basic Android application, you need at least:
 
 *  jme3-core
 *  jme3-android
@@ -58,24 +45,23 @@ For a basic android application to work you need to import at least
 
 === Gradle
 
-[source]
+[source,groovy]
 ----
 repositories {
-    jcenter()
-    //maven { url "http://dl.bintray.com/jmonkeyengine/org.jmonkeyengine" }
+    mavenCentral()
 }
 
 def jme3 = [v:'3.3.2-stable', g:'org.jmonkeyengine']
 dependencies {
-	compile "${jme3.g}:jme3-core:${jme3.v}"
-	runtime "${jme3.g}:jme3-desktop:${jme3.v}"
-	runtime "${jme3.g}:jme3-lwjgl:${jme3.v}"
+    implementation "${jme3.g}:jme3-core:${jme3.v}"
+    runtimeOnly "${jme3.g}:jme3-desktop:${jme3.v}"
+    runtimeOnly "${jme3.g}:jme3-lwjgl:${jme3.v}"
 }
 ----
 
 === Maven
 
-[source]
+[source,xml]
 ----
   <properties>
     <jme3_g>org.jmonkeyengine</jme3_g>
@@ -84,8 +70,8 @@ dependencies {
 
   <repositories>
     <repository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
+      <id>mvnrepository</id>
+      <url>https://repo1.maven.org/maven2/</url>
     </repository>
   </repositories>
 
@@ -105,100 +91,6 @@ dependencies {
       <groupId>${jme3_g}</groupId>
       <artifactId>jme3-lwjgl</artifactId>
       <version>${jme3_v}</version>
-    </dependency>
-  </dependencies>
-----
-
-== jME3.0
-
-You can use jME3 with maven compatible build systems, the official maven repository for jME3:
-
-* link:https://bintray.com/jmonkeyengine/com.jme3[Bintray repo: com.jme3] (click on the `SET ME UP` button to view instruction for Gradle, Maven,...)
-
-
-The group id for all jME3 libraries is `com.jme3`, the following artifacts are currently available (version `3.0.10`):
-
-*  jme3-core - Core libraries needed for all jME3 projects
-*  jme3-effects - Effects libraries for water and other post filters
-*  jme3-networking - jME3 networking libraries (aka spidermonkey)
-*  jme3-plugins - Loader plugins for OgreXML and jME-XML
-*  jme3-jogg - Loader for jogg audio files
-*  jme3-terrain - Terrain generation +++<abbr title="Application Programming Interface">API</abbr>+++
-*  jme3-blender - Blender file loader, only works on desktop renderers
-*  jme3-jbullet - Physics support using jbullet (desktop only) *Only jme3-jbullet OR jme3-bullet can be used*
-*  jme3-bullet - Physics support using native bullet, needs jme3-bullet-natives or jme3-bullet-natives-android (alpha)
-*  jme3-bullet-natives - Native libraries needed for bullet (not jbullet) on desktop (alpha)
-*  jme3-bullet-natives-android - Native libraries needed for bullet (not jbullet) on android (alpha)
-*  jme3-niftygui - NiftyGUI support for jME3
-*  jme3-desktop - Parts of the jME3 +++<abbr title="Application Programming Interface">API</abbr>+++ that are only compatible with desktop renderers, needed for image loading on desktop
-*  jme3-lwjgl - Desktop renderer for jME3
-*  jme3-android - Android renderer for jME3
-*  jme3-ios - iOS renderer for jME3
-
-For a basic desktop application to work you need to import at least
-
-*  jme3-core
-*  jme3-desktop
-*  jme3-lwjgl
-
-For a basic android application to work you need to import at least
-
-*  jme3-core
-*  jme3-android
-
-
-=== Gradle
-
-If you happen to be using Gradle, you'll first need to add the repository, perhaps so it looks like this:
-
-[source]
-----
-repositories {
-    jcenter()
-    maven { url "http://dl.bintray.com/jmonkeyengine/com.jme3" }
-}
-
-def jme3 = [v:'3.0.10', g:'com.jme3']
-dependencies {
-	compile "${jme3.g}:jme3-core:${jme3.v}"
-	runtime "${jme3.g}:jme3-desktop:${jme3.v}"
-	runtime "${jme3.g}:jme3-lwjgl:${jme3.v}"
-}
-----
-
-=== Maven
-
-[source]
-----
-  <properties>
-    <jme3_g>com.jme3</jme3_g>
-    <jme3_v>3.0.10</jme3_v>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>com_jme3-repo</id>
-      <url>http://dl.bintray.com/jmonkeyengine/com.jme3</url>
-    </repository>
-  </repositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>${jme3_g}</groupId>
-      <artifactId>jme3-core</artifactId>
-      <version>${jme3_v}</version>
-    </dependency>
-    <dependency>
-      <groupId>${jme3_g}</groupId>
-      <artifactId>jme3-desktop</artifactId>
-      <version>${jme3_v}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>${jme3_g}</groupId>
-      <artifactId>jme3-lwjgl</artifactId>
-      <version>${jme3_v}</version>
-      <scope>runtime</scope>
     </dependency>
   </dependencies>
 ----


### PR DESCRIPTION
This PR fixes some issues with the current "Maven Artifacts" page:

+ Wiki pages are specific to major releases, so don't document old releases such as v3.0 and v3.1.
+ Bintray is gone and JCenter is unmaintained and being decommissioned, so point people to Maven Central repo instead.
+ Don't mention artifacts that won't exist in v3.4 (jme3-blender, jme3-bullet, jme3-bullet-native, jme3-bullet-native-android, and jme3-jogl).
+ Mention artifacts that weren't available prior to v3.4 (jme3-examples, jme3-testdata).
+ Improve descriptions of libraries: mention glTF, link to Ogg webpage
+ Use modern dependency notation in Gradle scripts.

Most of these changes should probably be backported to older versions of maven.adoc.