### PR TITLE
contributions.adoc: remove references to Bintray and JCenter

### DIFF
--- a/docs/modules/contributions/pages/contributions.adoc
+++ b/docs/modules/contributions/pages/contributions.adoc
@@ -1,13 +1,13 @@
 = Contributions
 :revnumber: 2.0
 :revdate: 2020/07/11
-:url-bintray: https://bintray.com
 :url-contribs: https://github.com/jMonkeyEngine-Contributions
 :url-core: https://hub.jmonkeyengine.org/badges/103/core-developer
 :url-enginelib: https://github.com/jMonkeyEngine/jmonkeyengine/tree/master
 :url-forum-user: https://hub.jmonkeyengine.org/u
 :url-github: https://github.com
 :url-jitpack: https://jitpack.io
+:url-mcentral: https://search.maven.org/search?
 :url-mirrors: https://github.com/jMonkeyEngine-mirrors
 :url-wiki: https://wiki.jmonkeyengine.org/docs/3.3
 
@@ -27,328 +27,6 @@ JMonkeyEngine projects built using https://gradle.org/[Gradle]
 or https://maven.apache.org/[Maven]
 can easily incorporate pre-built libraries from public Maven repositories.
 
-=== At JCenter
-
-The table below lists JME-related libraries available primarily from JCenter.
-"GroupID:ArtifactID" entries link to Bintray package information;
-follow these links to determine the version ID of the latest release.
-"Name" entries link to relevant documentation, if any.
-
-[cols="20,20,15,35,10",grid="none",options="header"]
-|===
-|Name
-|Purpose
-|Maintainer(s)
-|GroupID:ArtifactID
-|Source code
-
-|https://1337atr.weebly.com/jttf.html[jME-TTF]
-|Render TrueType fonts
-|(none)
-|{url-bintray}/tryder/maven/jme-ttf[com.atr:jme-ttf]
-|{url-github}/ATryder/jME-TTF[GitHub]
-
-
-|{url-github}/stephengold/Heart#readme[Heart]
-|General-purpose toolkit
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/Heart[com.github.stephengold:Heart]
-|{url-github}/stephengold/Heart[GitHub]
-
-|{url-github}/stephengold/jme3-utilities#readme[Jme3-utilities-nifty]
-|Graphical user interface
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/jme3-utilities-nifty[com.github.stephengold:jme3-utilities-nifty]
-|{url-github}/stephengold/jme3-utilities/tree/master/nifty[GitHub]
-
-|{url-github}/stephengold/jme3-utilities#readme[Jme3-utilities-ui]
-|Modal hotkeys and help screens
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/jme3-utilities-ui[com.github.stephengold:jme3-utilities-ui]
-|{url-github}/stephengold/jme3-utilities/tree/master/ui[GitHub]
-
-|https://stephengold.github.io/Minie/minie/overview.html[Minie]
-|3-D physics simulation
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/Minie[com.github.stephengold:Minie]
-|{url-github}/stephengold/Minie[GitHub]
-
-|{url-github}/stephengold/SkyControl#readme[SkyControl]
-|Sky simulation
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/SkyControl[com.github.stephengold:SkyControl]
-|{url-github}/stephengold/SkyControl[GitHub]
-
-|{url-github}/stephengold/Wes#readme[Wes]
-|Animation editing and retargeting
-|{url-forum-user}/sgold[sgold]
-|{url-bintray}/stephengold/com.github.stephengold/Wes[com.github.stephengold:Wes]
-|{url-github}/stephengold/Wes[GitHub]
-
-
-
-|{url-mirrors}/jfx-11-jme-embedded-jayfella-github#readme[jfx-11-jme-embedded]
-|Embed JME into JavaFX
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jfx-11-jme-embedded[com.jayfella:jfx-11-jme-embedded]
-|{url-mirrors}/jfx-11-jme-embedded-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-easings-jayfella-github#readme[jme-easing]
-|Easing functions for animation
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-easing[com.jayfella:jme-easing]
-|{url-mirrors}/jme-easings-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-fastnoise-jayfella-github#readme[jme-fastnoise]
-|Generate 2-D noise
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-fastnoise[com.jayfella:jme-fastnoise]
-|{url-mirrors}/jme-fastnoise-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-jfx-11-jayfella-github#readme[jme-jfx-11]
-|JavaFX GUI bridge
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-jfx-11[com.jayfella:jme-jfx-11]
-|{url-mirrors}/jme-jfx-11-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-position-plotters-jayfella-github#readme[jme-position-plotters]
-|Place things randomly on a mesh
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-position-plotters[com.jayfella:jme-position-plotters]
-|{url-mirrors}/jme-position-plotters-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-swing-devkit-jayfella-github#readme[jme-swing-devkit]
-|Development kit using Swing
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-swing-devkit[com.jayfella:jme-swing-devkit]
-|{url-mirrors}/jme-swing-devkit-jayfella-github[GitHub]
-
-|{url-mirrors}/jme-world-pager-jayfella-github#readme[jme-world-pager]
-|Generate infinite worlds
-|(none)
-|{url-bintray}/jayfella/com.jayfella/jme-world-pager[com.jayfella:jme-world-pager]
-|{url-mirrors}/jme-world-pager-jayfella-github[GitHub]
-
-|{url-mirrors}/lemur-menubar-jayfella-github#readme[Lemur-MenuBar]
-|Menu system for the Lemur GUI
-|(none)
-|{url-bintray}/jayfella/com.jayfella/lemur-menubar[com.jayfella:lemur-menubar]
-|{url-mirrors}/lemur-menubar-jayfella-github[GitHub]
-
-|{url-mirrors}/lemur-themer-jayfella-github#readme[Lemur-Themer]
-|Create and edit Lemur GUI themes
-|(none)
-|{url-bintray}/jayfella/com.jayfella/lemur-themer[com.jayfella:lemur-themer]
-|{url-mirrors}/lemur-themer-jayfella-github[GitHub]
-
-|{url-mirrors}/plugin-manager-jayfella-github#readme[Plugin Manager]
-|Framework for software plugins
-|(none)
-|{url-bintray}/jayfella/com.jayfella/plugin-manager[com.jayfella:plugin-manager]
-|{url-mirrors}/plugin-manager-jayfella-github[GitHub]
-
-|{url-mirrors}/property-inspector-jayfella-github#readme[Property Inspector]
-|Lemur GUI to edit object properties
-|(none)
-|{url-bintray}/jayfella/com.jayfella/property-inspector[com.jayfella:property-inspector]
-|{url-mirrors}/property-inspector-jayfella-github[GitHub]
-
-
-|{url-github}/rvandoosselaer/Blocks/wiki[Blocks]
-|Customizable voxel engine
-|{url-forum-user}/remy_vd[remy_vd]
-|{url-bintray}/remyvd/rvandoosselaer/blocks[com.rvandoosselaer:blocks]
-|{url-github}/rvandoosselaer/Blocks[GitHub]
-
-
-|JME Convert
-|Asset conversion
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/jmec[com.simsilica:jmec]
-|{url-github}/Simsilica/JmeConvert[GitHub]
-
-|{url-contribs}/Lemur/wiki[Lemur]
-|Modular lightweight user interface
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/lemur[com.simsilica:lemur]
-|{url-contribs}/Lemur[GitHub]
-
-|Lemur-props
-|Lemur GUI panel for editable bean properties
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/lemur-props[com.simsilica:lemur-props]
-|{url-contribs}/Lemur/tree/master/extensions/LemurProps[GitHub]
-
-|{url-contribs}/Lemur/wiki[Lemur-proto]
-|More Lemur GUI components in incubation
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/lemur-proto[com.simsilica:lemur-proto]
-|{url-contribs}/Lemur/tree/master/extensions/LemurProto[GitHub]
-
-|{url-github}/Simsilica/SimEthereal/wiki[Sim-Ethereal]
-|Synchronize objects over a network
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/sim-ethereal[com.simsilica:sim-ethereal]
-|{url-github}/Simsilica/SimEthereal[GitHub]
-
-|Sim-Math
-|Double-based 3-D math
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/sim-math[com.simsilica:sim-math]
-|{url-github}/Simsilica/SimMath[GitHub]
-
-|SiO2
-|General-purpose game toolkit
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/sio2[com.simsilica:sio2]
-|{url-github}/Simsilica/SiO2[GitHub]
-
-|{url-contribs}/zay-es/wiki[Zay-ES]
-|Entity component system (ECS)
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/zay-es[com.simsilica:zay-es]
-|{url-contribs}/zay-es[GitHub]
-
-|{url-contribs}/zay-es/wiki[Zay-ES-Net]
-|Zay-ES networking layer
-|{url-forum-user}/pspeed[pspeed]
-|{url-bintray}/simsilica/Sim-tools/zay-es-net[com.simsilica:zay-es-net]
-|{url-contribs}/zay-es/tree/master/extensions/Zay-ES-Net[GitHub]
-
-
-|{url-wiki}/documentation.html[jme3-android]
-|Support for Android platforms JNI
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-android[org.jmonkeyengine:jme3-android]
-|{url-enginelib}/jme3-android[GitHub]
-
-|{url-wiki}/documentation.html[jme3-android-native]
-|Support for Android platforms native code
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-android-native[org.jmonkeyengine:jme3-android-native]
-|{url-enginelib}/jme3-android-native[GitHub]
-
-|{url-wiki}/documentation.html[jme3-blender]
-|Blender importer
-|(none)
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-blender[org.jmonkeyengine:jme3-blender]
-|{url-contribs}/BlenderLoader[GitHub]
-
-|{url-wiki}/physics/physics.html[jme3-bullet]
-|3-D physics simulation JNI
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-bullet[org.jmonkeyengine:jme3-bullet]
-|{url-enginelib}/jme3-bullet[GitHub]
-
-|{url-wiki}/physics/physics.html[jme3-bullet-native]
-|3-D physics simulation desktop native code
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-bullet-native[org.jmonkeyengine:jme3-bullet-native]
-|{url-enginelib}/jme3-bullet-native[GitHub]
-
-|{url-wiki}/documentation.html[jme3-bullet-native-android]
-|3-D physics simulation Android native code
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-bullet-native-android[org.jmonkeyengine:jme3-bullet-native-android]
-|{url-enginelib}/jme3-bullet-native-android[GitHub]
-
-|{url-wiki}/documentation.html[jme3-core]
-|Game engine core
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-core[org.jmonkeyengine:jme3-core]
-|{url-enginelib}/jme3-core[GitHub]
-
-|{url-wiki}/documentation.html[jme3-desktop]
-|Support for desktop platforms
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-desktop[org.jmonkeyengine:jme3-desktop]
-|{url-enginelib}/jme3-desktop[GitHub]
-
-|{url-wiki}/documentation.html[jme3-effects]
-|Filters and special effects
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-effects[org.jmonkeyengine:jme3-effects]
-|{url-enginelib}/jme3-effects[GitHub]
-
-|{url-wiki}/documentation.html[jme3-examples]
-|Engine test/example/demo apps
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-examples[org.jmonkeyengine:jme3-examples]
-|{url-enginelib}/jme3-examples[GitHub]
-
-|{url-wiki}/documentation.html[jme3-ios]
-|Support for iOS platforms
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-ios[org.jmonkeyengine:jme3-ios]
-|{url-enginelib}/jme3-ios[GitHub]
-
-|{url-wiki}/physics/physics.html[jme3-jbullet]
-|3-D physics simulation on JVM
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-jbullet[org.jmonkeyengine:jme3-jbullet]
-|{url-enginelib}/jme3-jbullet[GitHub]
-
-|{url-wiki}/documentation.html[jme3-jogg]
-|Play OGG audio files
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-jogg[org.jmonkeyengine:jme3-jogg]
-|{url-enginelib}/jme3-jogg[GitHub]
-
-|{url-wiki}/documentation.html[jme3-jogl]
-|JOGL backend
-|{url-forum-user}/gouessej[gouessej]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-jogl[org.jmonkeyengine:jme3-jogl]
-|{url-enginelib}/jme3-jogl[GitHub]
-
-|{url-wiki}/documentation.html[jme3-lwjgl]
-|LWJGL v2 backend
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-lwjgl[org.jmonkeyengine:jme3-lwjgl]
-|{url-enginelib}/jme3-lwjgl[GitHub]
-
-|{url-wiki}/documentation.html[jme3-lwjgl3]
-|LWJGL v3 backend
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-lwjgl3[org.jmonkeyengine:jme3-lwjgl3]
-|{url-enginelib}/jme3-lwjgl3[GitHub]
-
-|{url-wiki}/networking/networking.html[SpiderMonkey]
-|Multi-player networking
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-networking[org.jmonkeyengine:jme3-networking]
-|{url-enginelib}/jme3-networking[GitHub]
-
-|{url-wiki}/core/gui/nifty_gui.html[Nifty]
-|Graphical user interface
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-niftygui[org.jmonkeyengine:jme3-niftygui]
-|{url-enginelib}/jme3-niftygui[GitHub]
-
-|{url-wiki}/documentation.html[jme3-plugins]
-|Import more file formats
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-plugins[org.jmonkeyengine:jme3-plugins]
-|{url-enginelib}/jme3-plugins[GitHub]
-
-|{url-wiki}/core/terrain/terrain.html[TerraMonkey]
-|Terrain
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-terrain[org.jmonkeyengine:jme3-terrain]
-|{url-enginelib}/jme3-terrain[GitHub]
-
-|{url-wiki}/core/vr/virtualreality.html[jme3-vr]
-|Virtual reality
-|{url-core}[Core developers]
-|{url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-vr[org.jmonkeyengine:jme3-vr]
-|{url-enginelib}/jme3-vr[GitHub]
-
-
-|===
-
-=== At other public repositories
-
-The table below lists JME-related libraries available primarily
-from public Maven repositories other than JCenter.
 "GroupID:ArtifactID" entries link to package information;
 follow these links to determine the version ID of the latest release.
 "Name" entries link to relevant documentation, if any.
@@ -361,6 +39,57 @@ follow these links to determine the version ID of the latest release.
 |Maven repository URL +
  GroupID:ArtifactID
 |Source code
+
+|https://1337atr.weebly.com/jttf.html[jME-TTF]
+|Render TrueType fonts
+|(none)
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:jme-ttf[com.github.stephengold:jme-ttf]
+|{url-github}/ATryder/jME-TTF[GitHub]
+
+
+|{url-github}/stephengold/Heart#readme[Heart]
+|General-purpose toolkit
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:Heart[com.github.stephengold:Heart]
+|{url-github}/stephengold/Heart[GitHub]
+
+|{url-github}/stephengold/jme3-utilities#readme[Jme3-utilities-nifty]
+|Graphical user interface
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:jme3-utilities-nifty[com.github.stephengold:jme3-utilities-nifty]
+|{url-github}/stephengold/jme3-utilities/tree/master/nifty[GitHub]
+
+|{url-github}/stephengold/jme3-utilities#readme[Jme3-utilities-ui]
+|Modal hotkeys and help screens
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:jme3-utilities-ui[com.github.stephengold:jme3-utilities-ui]
+|{url-github}/stephengold/jme3-utilities/tree/master/ui[GitHub]
+
+|https://stephengold.github.io/Minie/minie/overview.html[Minie]
+|3-D physics simulation
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:Minie[com.github.stephengold:Minie]
+|{url-github}/stephengold/Minie[GitHub]
+
+|{url-github}/stephengold/SkyControl#readme[SkyControl]
+|Sky simulation
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:SkyControl[com.github.stephengold:SkyControl]
+|{url-github}/stephengold/SkyControl[GitHub]
+
+|{url-github}/stephengold/Wes#readme[Wes]
+|Animation editing and retargeting
+|{url-forum-user}/sgold[sgold]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:Wes[com.github.stephengold:Wes]
+|{url-github}/stephengold/Wes[GitHub]
+
 
 |{url-github}/riccardobl/jme3-bullet-vhacd#readme[V-HACD Collision Shape Factory]
 |Decompose meshes into convex collision shapes
@@ -377,43 +106,12 @@ follow these links to determine the version ID of the latest release.
 |{url-github}/riccardobl/jme-igui[GitHub]
 
 
-|{url-github}/riccardobl/jme-igui#readme[Effekseer Native]
-|Render effects made with Effekseer
-|{url-forum-user}/RiccardoBlb[RiccardoBlb]
-|\https://dl.bintray.com/riccardo/effekseer +
- {url-bintray}/riccardo/effekseer/jme-effekseerNative[com.jme.effekseer:jme-effekseerNative]
-|{url-github}/riccardobl/jme-effekseerNative[GitHub]
-
-|{url-github}/jmePhonon/jmePhonon#readme[jmePhonon]
-|Steam(R) audio
-|{url-forum-user}/RiccardoBlb[RiccardoBlb]
-|\https://dl.bintray.com/jmephonon/jmePhonon +
- {url-bintray}/jmephonon/jmePhonon/jmePhonon[com.jme3.phonon:jmePhonon]
-|{url-github}/jmePhonon/jmePhonon[GitHub]
-
-
-|{url-wiki}/documentation.html[jme3-testdata]
-|Assets for engine test/example/demo apps
-|{url-core}[Core developers]
-|\https://dl.bintray.com/jmonkeyengine/org.jmonkeyengine +
- {url-bintray}/jmonkeyengine/org.jmonkeyengine/jme3-testdata[org.jmonkeyengine:jme3-testdata]
-|{url-enginelib}/jme3-testdata[GitHub]
-
-
 |{url-wiki}/contributions/gui/tonegodgui/tonegodgui.html[ToneGod GUI]
 |Native graphical user interface
 |(none)
-|\https://dl.bintray.com/stephengold/tonegod +
- {url-bintray}/stephengold/tonegod/tonegodgui[tonegod:tonegodgui]
+|\https://repo1.maven.org/maven2 +
+ {url-mcentral}q=g:com.github.stephengold%20AND%20a:tonegodgui[com.github.stephengold:tonegodgui]
 |{url-github}/stephengold/tonegodgui[GitHub]
-
-
-|{url-github}/riccardobl/f3b#readme[F3b]
-|Import assets from Blender
-|{url-forum-user}/RiccardoBlb[RiccardoBlb]
-|\https://dl.bintray.com/riccardo/f3b +
- {url-bintray}/riccardo/f3b/jme_f3b[wf.frk.f3b:jme_f3b]
-|{url-github}/riccardobl/f3b[GitHub]
 
 
 |===
@@ -423,12 +121,6 @@ follow these links to determine the version ID of the latest release.
 
 This is the main repository for jmonkey contributions:
 link:https://github.com/jMonkeyEngine-Contributions[https://github.com/jMonkeyEngine-Contributions]
-
-
-== David's Repo
-
-A collection of jME libraries and assets by David Bernard:
-link:https://bintray.com/jmonkeyengine/contrib[https://bintray.com/jmonkeyengine/contrib]
 
 
 == Forum: Contributions


### PR DESCRIPTION
This pull request addresses yet another piece of the https://github.com/jMonkeyEngine/jmonkeyengine/issues/1468 puzzle.

The "jme-ttf" and "tonegodgui" libraries and all of sgold's libraries are now available from the Maven Central Repository, so their table entries are updated accordingly.

All the JME libraries are available from Maven Central, but this page is really about unofficial contributions. The official libraries are covered by the "maven.adoc" page, so their entries here are deleted.

Libraries that are, as far as I know, only available from JCenter or Bintray are deleted. While many (if not all) of these can still be used as dependencies (provided one knows a valid version ID), the weblinks to determine the latest version ID are now 404s. These libraries can be added back as soon as full information becomes available.
