### PR TITLE
Deemphasis nifty

### DIFF
--- a/docs/modules/contributions/pages/gui/topic_contributions_gui.adoc
+++ b/docs/modules/contributions/pages/gui/topic_contributions_gui.adoc
@@ -3,6 +3,5 @@ mitm001
 :description: GUI contributed libraries for the jmonkey engine.
 :keywords: gui, documentation, input, control, hud, contributions
 
-The official engine GUI library is xref:core:gui/nifty_gui.adoc[Nifty GUI]. This
-topic contains user contributed GUI libraries. The most popular and current being
+This topic contains user contributed GUI libraries. The most popular and current being
 Lemur.

--- a/docs/modules/core/pages/gui/topic_gui.adoc
+++ b/docs/modules/core/pages/gui/topic_gui.adoc
@@ -3,5 +3,5 @@ mitm001
 :description: GUI libraries for the jmonkey engine.
 :keywords: gui, documentation, input, control, hud
 
-JMonkey engine has a number of UI libraries to choose from which are maintained by the community and can be found under xref:contributions:gui/topic_contributions_gui.adoc[User Contributions]. 
+jMonkeyEngine has a number of UI libraries to choose from which are maintained by the community and can be found under xref:contributions:gui/topic_contributions_gui.adoc[User Contributions]. 
 Additionally Nifty has historically been integrated into the engine but is not maintained by the Engine Team.

--- a/docs/modules/core/pages/gui/topic_gui.adoc
+++ b/docs/modules/core/pages/gui/topic_gui.adoc
@@ -3,7 +3,5 @@ mitm001
 :description: GUI libraries for the jmonkey engine.
 :keywords: gui, documentation, input, control, hud
 
-Nifty is the official GUI for the engine. It is a GUI library that is not
-maintained by the Engine Team, but it is fully integrated into the engine itself.
-
-There are other GUI libraries that are listed under xref:contributions:gui/topic_contributions_gui.adoc[User Contributions].
+JMonkey engine has a number of UI libraries to choose from which are maintained by the community and can be found under xref:contributions:gui/topic_contributions_gui.adoc[User Contributions]. 
+Additionally Nifty has historically been integrated into the engine but is not maintained by the Engine Team.


### PR DESCRIPTION
As nifty is no longer actively maintained de-emphasise it in the wiki.

This came out of a discussion on https://hub.jmonkeyengine.org/t/does-anyone-know-if-niftygui-is-still-being-mantained/44168/17