### PR TITLE
Updated the tip for testdata to show instructions for gradle

### DIFF
--- a/docs/modules/tutorials/partials/add-testdata-tip.adoc
+++ b/docs/modules/tutorials/partials/add-testdata-tip.adoc
@@ -1,4 +1,8 @@
 [TIP]
 ====
-To use the example assets in a new jMonkeyEngine SDK project, right-click your project, select menu:Properties[Libraries > Add Library], and add the "`jme3-test-data`" library.
+To use the example assets in a new jMonkeyEngine SDK project:
+
+ANT: Right-click your project, select menu:Properties[Libraries > Add Library], and add the "`jme3-test-data`" library.
+
+GRADLE: In *build.gradle* change `jmeVer` from 3.3.0-stable to 3.4.0-stable(or whatever the current latest version is), replace `jCenter()` with `mavenCentral()`. Then, in the dependency section you need to add `implementation "org.jmonkeyengine:jme3-testdata:$\{jmeVer\}"`. If you want to support opening model files in other formats(xml, etc), add `implementation "org.jmonkeyengine:jme3-plugins:$\{jmeVer\}"`. Once that is done, in the projects tab right click on the *Configurations*, select *Download Sources*, and after it's done, *Download Java docs*.
 ====


### PR DESCRIPTION
While following the tutorials, I had to search the forum to figure out how to add testdata to the projects. Hopefully this commit could save other people some time.