### PR TITLE
Update scene_composer.adoc

### DIFF
--- a/docs/modules/sdk/pages/scene_composer.adoc
+++ b/docs/modules/sdk/pages/scene_composer.adoc
@@ -14,10 +14,19 @@ Most buttons in the SceneComposer have tooltips that appear when you hover the m
 *  Left-click and drag to rotate the camera around the cam center
 *  Right-click and drag to move the cam center
 *  Scroll the mouse wheel to zoom in/out the cam center
-*  Left-click a geometry to select it
-*  Right-click a geometry to place the cursor
+*  Right-click a geometry to select it
+*  Left-click a geometry to place the cursor
 
 In the SceneComposer toolbar are buttons to snap the camera to the cursor, snap the cursor to the selection and etc.
+
+Hot keys for manipulating objects:
+
+G - Move
+R - Rotate
+S - Scale
+
+In addition, you can limit the manipulation to a certain axis by pressing X, Y, or Z.
+By default the object's local reference will be used. Global or Camera reference can be selected in the SceneComposer window.
 
 
 == Creating a scene file


### PR DESCRIPTION
Corrected mouse click documentation.
Added hotkeys for manipulating objects.

Although I'm not sure why the button clicks were changed (if they were). More natural to me to select with left click.