### PR TITLE
Add Tamarin into the wiki as a user contribution

### DIFF
--- a/docs/modules/contributions/nav.adoc
+++ b/docs/modules/contributions/nav.adoc
@@ -21,5 +21,7 @@
 ** Tools
 *** xref:tools/navigation.adoc[Mercator Projection Tool (Marine Navigation)]
 *** xref:tools/charts.adoc[Visualizing Maps in JME3 (Marine Charts)]
+** xref:vr/topic_contributions_vr.adoc[Virtual Reality (And augmented reality)]
+*** xref:contributions.adoc#Tamarin-OpenXR[Tamarin OpenXR]
 ** Projects
 *** xref:projects/rise_of_mutants_project.adoc[Rise of Mutants Project]

--- a/docs/modules/contributions/pages/contributions.adoc
+++ b/docs/modules/contributions/pages/contributions.adoc
@@ -319,7 +319,7 @@ a| Yes
 
 === Tamarin OpenXR
 
-Tamarin provides OpenXR fuctionality to enable JMonkey applications to run on VR headsets. It provides full support for the headset, controller actions, haptic feadback and a sample set of vr hands
+Tamarin provides OpenXR functionality to enable jMonkey applications to run on VR headsets. It provides full support for the headset, controller actions, haptic feedback and a sample set of vr hands.
 
 [cols="2", options="header"]
 |===

--- a/docs/modules/contributions/pages/contributions.adoc
+++ b/docs/modules/contributions/pages/contributions.adoc
@@ -317,6 +317,27 @@ a| Yes
 
 |===
 
+=== Tamarin OpenXR
+
+Tamarin provides OpenXR fuctionality to enable JMonkey applications to run on VR headsets. It provides full support for the headset, controller actions, haptic feadback and a sample set of vr hands
+
+[cols="2", options="header"]
+|===
+
+a| *Contact person*
+a| {url-forum-user}/richtea[richtea]
+
+a| *Documentation*
+a| {url-github}/oneMillionWorlds/Tamarin/wiki[Tamarin wiki]
+
+a| *Available as SDK plugin*
+a| No
+
+a| *Work in progress*
+a| No (Actively maintained and improved)
+
+|===
+
 == Assets packs
 
 _No contributions yet_

--- a/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
+++ b/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
@@ -1,0 +1,5 @@
+= VR Contributions
+:description: VR contributed libraries for the jmonkey engine.
+:keywords: vr, documentation, input, control, hud, contributions
+
+This topic contains user contributed Virtual Reality (and augmented reality) libraries. The most popular and current being Tamarin.

--- a/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
+++ b/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
@@ -1,5 +1,5 @@
 = VR Contributions
 :description: VR contributed libraries for the jmonkey engine.
-:keywords: vr, documentation, input, control, hud, contributions
+:keywords: vr, documentation, ar, openxr, contributions
 
 This topic contains user contributed Virtual Reality (and augmented reality) libraries. The most popular and current being Tamarin.

--- a/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
+++ b/docs/modules/contributions/pages/vr/topic_contributions_vr.adoc
@@ -2,4 +2,4 @@
 :description: VR contributed libraries for the jmonkey engine.
 :keywords: vr, documentation, ar, openxr, contributions
 
-This topic contains user contributed Virtual Reality (and augmented reality) libraries. The most popular and current being Tamarin.
+This topic contains user contributed Virtual Reality (and augmented reality) libraries.

--- a/docs/modules/core/pages/vr/virtualreality.adoc
+++ b/docs/modules/core/pages/vr/virtualreality.adoc
@@ -6,7 +6,7 @@ Please see this link:https://hub.jmonkeyengine.org/t/official-vr-module/37830/67
 
 == Introduction
 
-jMonkeyEngine 3 supports several VR specifications, the most modern of those is OpenVR, this is currently a widely supported standard. However, vendors are beginning to move towards OpenXR as a fully open cross-platform standard. OpenXR is available with jMonkeyEngine via  xref:contributions:vr/topic_contributions_vr.adoc[user contributed virtual reality libraries].
+jMonkeyEngine 3 supports several VR specifications. The most modern of those is OpenVR, which is currently a widely supported standard. However, vendors are beginning to move towards OpenXR as a fully open cross-platform standard. OpenXR is available with jMonkeyEngine via  xref:contributions:vr/topic_contributions_vr.adoc[user contributed virtual reality libraries].
 
 The known supported systems are:
 

--- a/docs/modules/core/pages/vr/virtualreality.adoc
+++ b/docs/modules/core/pages/vr/virtualreality.adoc
@@ -6,11 +6,15 @@ Please see this link:https://hub.jmonkeyengine.org/t/official-vr-module/37830/67
 
 == Introduction
 
-jMonkeyEngine 3 has a wide range of support for Virtual Reality (VR). The known supported systems are:
+jMonkeyEngine 3 supports several VR specifications, the most modern of those is OpenVR, this is currently a widely supported standard. However, vendors are beginning to move towards OpenXR as a fully open cross-platform standard. OpenXR is available with jMonkeyEngine via  xref:contributions:vr/topic_contributions_vr.adoc[user contributed virtual reality libraries].
+
+The known supported systems are:
 
 HTC Vive and systems supporting SteamVR/OpenVR
 
 Native Oculus Rift support (and through SteamVR)
+
+Oculus Quest 2 (through SteamVR with Virtual Desktop)
 
 Razer HDK and systems supporting OSVR
 

--- a/docs/modules/core/pages/vr/virtualreality.adoc
+++ b/docs/modules/core/pages/vr/virtualreality.adoc
@@ -6,7 +6,7 @@ Please see this link:https://hub.jmonkeyengine.org/t/official-vr-module/37830/67
 
 == Introduction
 
-jMonkeyEngine 3 supports several VR specifications. The most modern of those is OpenVR, which is currently a widely supported standard. However, vendors are beginning to move towards OpenXR as a fully open cross-platform standard. OpenXR is available with jMonkeyEngine via  xref:contributions:vr/topic_contributions_vr.adoc[user contributed virtual reality libraries].
+jMonkeyEngine 3 supports several VR specifications. The most modern of those is OpenVR, which is currently a widely supported standard. However, vendors are beginning to move towards OpenXR as a fully open cross-platform standard. OpenXR is available with jMonkeyEngine via xref:contributions:vr/topic_contributions_vr.adoc[user contributed virtual reality libraries].
 
 The known supported systems are:
 


### PR DESCRIPTION
Added Tamarin into the wiki as a user contributed library. Made it clear that jmonkeyEngine only natively supports up to OpenVR but OpenXR can be used via user contributed libraries (currently just Tamarin to my knowledge)