### PR TITLE
README.adoc:  update/correct the build procedure

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,14 +17,12 @@ NOTE: Read the link:https://wiki.jmonkeyengine.org/docs-wiki/3.4/wiki_contributo
 
 == Build & Preview
 
-To set up the Antora environment, you'll need Nodejs (tested with node 12).
+To set up the Antora environment, you'll need Node.js and Nvm.
 
-From your local wiki directory.
-
-Run:
+From your local wiki directory, run:
 ```
 npm install
-npm run buildDocs
+npx antora wiki-playbook.yml
 ```
 
 This will install the needed dependencies and run the static site generator. The documentation will be output to the directory `build/site`.


### PR DESCRIPTION
Per discussion at https://hub.jmonkeyengine.org/t/solved-wiki-build-fails/48111 the build procedures in "README.adoc" don't work, at least for some of us. This PR updates the readme to use the "npx" command.

I've tested the revised instructions  (with Node v20) on Linux and macOS. 